### PR TITLE
Add retries also to list_files

### DIFF
--- a/azure_blob_interface/azure_blob.py
+++ b/azure_blob_interface/azure_blob.py
@@ -174,11 +174,9 @@ class AzureStorageDriver(StorageDriver):
         for file_path in blob_file_paths:
             self.container.delete_blob(file_path)
 
-    def list_files(self,
-                   prefix: str,
-                   glob: str = None,
-                   recursive: bool = False,
-                   retries: int = 1):
+    def list_files(
+        self, prefix: str, glob: str = None, recursive: bool = False, retries: int = 1
+    ):
         """Assumes prefix is a directory and list all files and directories below it.
         If recursive is set, glob is ignored."""
 


### PR DESCRIPTION
I got ServiceResponseError (Connection aborted) also with list_files so I'm adding the same retry logic as with upload and download functions.