### PR TITLE
Feat/env name

### DIFF
--- a/azure_blob_interface/azure_blob.py
+++ b/azure_blob_interface/azure_blob.py
@@ -22,7 +22,7 @@ class AzureStorageDriver(StorageDriver):
         env_name: str = "ACCOUNT_URL",
         **kwargs,
     ):
-        self.container = self.get_container(container, **kwargs)
+        self.container = self.get_container(container, env_name=env_name, **kwargs)
         self.block_blob_service = self.get_block_blob_service(env_name, **kwargs)
         logging.getLogger("azure").setLevel(logging_level)
 


### PR DESCRIPTION
Hey guys

I came across this idea of adding env_name as a variable when instantiating an AzureStorageDriver. This enables us to do a thing like this:
```
sddatacube = azure_blob_interface.AzureStorageDriver(CONTAINER)
sdcoregistration = azure_blob_interface.AzureStorageDriver(
    COREGISTRATION_CONTAINER,
    env_name="AZURE_STORAGE_CONNECTION_STRING_COREGISTRATION"
)
```

I tested it out just now and it seems to work as intended and hopefully i have added the variable without adding it as a breaking change but feel free to comment here if you can see that it breaks a workflow that you have.